### PR TITLE
BUG: CircleCI cant connect to MySQL

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,6 @@ jobs:
           - APP_DEBUG=1
           - APP_SECRET=123
           - DATABASE_URL=mysql://bob:n0p455@127.0.0.1:3306/bob_test
-          - TEST_DATABASE_URL=mysql://bob:n0p455@127.0.0.1:3306/bob_test
       - image: mysql:5.7
         environment:
           - MYSQL_ROOT_PASSWORD=n0p455

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ jobs:
           - APP_ENV=test
           - APP_DEBUG=1
           - APP_SECRET=123
-          - DATABASE_URL=mysql://bob:n0p455@127.0.0.1:3306/bob_dev
+          - DATABASE_URL=mysql://bob:n0p455@127.0.0.1:3306/bob_test
           - TEST_DATABASE_URL=mysql://bob:n0p455@127.0.0.1:3306/bob_test
       - image: mysql:5.7
         environment:
@@ -27,6 +27,10 @@ jobs:
       - run:
           name: Composer install
           command: composer install -n --prefer-dist
+
+      - run:
+          name: Wait for MySQL to show up
+          command: dockerize -wait tcp://localhost:3306 -timeout 1m
 
       - run:
           name: Update schema (add all tables project needs)


### PR DESCRIPTION
When setting CircleCI I configured some details wrong:

1) we dont have bob_dev database :)
2) I forgot that CircleCI can be much faster than MySQL: from time to
time it can take up to a minute for MySQL to boot up so we need to use
'dockerize' to wait until it gets online


Closes #41